### PR TITLE
Update ReorderableListView docs to avoid confusion between desktop and mobile

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -29,6 +29,12 @@ import 'theme.dart';
 /// The [onReorder] parameter is required and will be called when a child
 /// widget is dragged to a new position.
 ///
+/// A drag handle is stacked over the center of edge on
+/// [TargetPlatformVariant.desktop] platforms. On [TargetPlatformVariant.mobile]
+/// platforms, no handle is visible and a long press anywhere on the item starts
+/// a drag. To change this behavior use
+/// [ReorderableListView.buildDefaultDragHandles].
+///
 /// {@tool dartpad --template=stateful_widget_scaffold}
 ///
 /// ```dart


### PR DESCRIPTION
Prevents this https://github.com/flutter/flutter/issues/80553 More info here https://github.com/flutter/flutter/pull/80576
